### PR TITLE
Comply with dl repo + allow bed row index as variant index

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ variables:
       command: |
         git clone git@github.com:kipoi/kipoi.git kipoi_pkg
         cd kipoi_pkg
-        git checkout plugin  # test already the future version of Kipoi
         pip install '.'
         cd ..
   install_kipoi_veff: &install_kipoi_veff

--- a/kipoi_veff/mutation_map.py
+++ b/kipoi_veff/mutation_map.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import os
 import tempfile
+import gzip
 
 import numpy as np
 import pandas as pd
@@ -208,7 +209,7 @@ def get_overlapping_bed_regions(dl_batch, seq_to_meta, bedtools_obj):
 def _generate_seq_sets_mutmap_iter(dl_ouput_schema, dl_batch, seq_to_mut, seq_to_meta,
                                    sample_counter, ref_sequences, bedtools_obj=None, vcf_fh=None,
                                    vcf_id_generator_fn=None, vcf_search_regions=False, generate_rc=True,
-                                   batch_size=32):
+                                   batch_size=32, bed_id_conv_fh = None):
     all_meta_fields = list(set(seq_to_meta.values()))
 
     num_samples_in_batch = len(dl_batch['metadata'][all_meta_fields[0]]["chr"])
@@ -236,7 +237,8 @@ def _generate_seq_sets_mutmap_iter(dl_ouput_schema, dl_batch, seq_to_mut, seq_to
             # vcf_search_regions == False means: rely completely on the variant id
             # so for every sample assert that all metadata ranges ids agree and then find the entry.
             query_vcf_records, query_process_lines, query_process_seq_fields, query_process_ids = \
-                get_variants_in_regions_sequential_vcf(dl_batch, seq_to_meta, vcf_fh, vcf_id_generator_fn)
+                get_variants_in_regions_sequential_vcf(dl_batch, seq_to_meta, vcf_fh, vcf_id_generator_fn,
+                                                       bed_id_conv_fh)
     elif bedtools_obj is not None:
         query_bed_regions, query_process_lines, query_process_seq_fields = \
             get_overlapping_bed_regions(dl_batch, seq_to_meta, bedtools_obj)
@@ -707,6 +709,7 @@ class MutationMap(object):
         import copy
         # If then where do I have to put my bed file in the command?
         temp_bed3_file = None
+        bed3_to_vcf_idx = None
         vcf_search_regions = True
 
         dataloader_args = copy.deepcopy(self.dataloader_args)
@@ -720,17 +723,22 @@ class MutationMap(object):
         # then generate the bed file.
         if self.exec_files_bed_keys is not None:
             temp_bed3_file = tempfile.mktemp()  # file path of the temp file
+            bed3_to_vcf_idx = tempfile.mktemp()
             if (vcf_to_region is not None) and (vcf_fpath is not None):
                 logger.warn("Using VCF file %s to define the dataloader intervals." % vcf_fpath)
                 vcf_search_regions = False
                 vcf_fh = cyvcf2.VCF(vcf_fpath, "r")
-                with BedWriter(temp_bed3_file) as ofh:
-                    for record in vcf_fh:
-                        if not is_indel_wrapper(record):
-                            region = vcf_to_region(record)
-                            id = vcf_id_generator_fn(record)
-                            for chrom, start, end in zip(region["chrom"], region["start"], region["end"]):
-                                ofh.append_interval(chrom=chrom, start=start, end=end, id=id)
+                bed_line_ctr = 0
+                with gzip.open(bed3_to_vcf_idx, "wb") as idx_conv_fh:
+                    with BedWriter(temp_bed3_file) as ofh:
+                        for record in vcf_fh:
+                            if not is_indel_wrapper(record):
+                                region = vcf_to_region(record)
+                                id = vcf_id_generator_fn(record)
+                                for chrom, start, end in zip(region["chrom"], region["start"], region["end"]):
+                                    ofh.append_interval(chrom=chrom, start=start, end=end, id=bed_line_ctr)
+                                    idx_conv_fh.write(("%s\t%d\n" % (id, bed_line_ctr)).encode())
+                                    bed_line_ctr += 1
                 vcf_fh.close()
             elif (bed_to_region is not None) and (bed_fpath is not None):
                 logger.warn("Using bed file %s to define the dataloader intervals." % bed_fpath)
@@ -758,7 +766,7 @@ class MutationMap(object):
             for k in self.exec_files_bed_keys:
                 dataloader_args[k] = temp_bed3_file
 
-        return dataloader_args, temp_bed3_file, vcf_search_regions
+        return dataloader_args, temp_bed3_file, vcf_search_regions, bed3_to_vcf_idx
 
     def _generate_mutation_map(self,
                                vcf_fpath=None,
@@ -811,7 +819,7 @@ class MutationMap(object):
         if (vcf_fpath is not None) and (vcf_id_generator_fn is None):
             raise Exception("If `vcf_fpath` is set then also `vcf_id_generator_fn` has to be defined!")
 
-        dataloader_args, temp_bed3_file, vcf_search_regions = self._setup_dataloader_kwargs(vcf_fpath,
+        dataloader_args, temp_bed3_file, vcf_search_regions, bed3_to_vcf_idx = self._setup_dataloader_kwargs(vcf_fpath,
                                                                                             bed_fpath,
                                                                                             vcf_to_region,
                                                                                             bed_to_region,
@@ -832,6 +840,10 @@ class MutationMap(object):
             vcf_fh = cyvcf2.VCF(vcf_fpath, "r")
         if bed_fpath is not None:
             bed_obj = BedTool(bed_fpath).tabix()
+
+        bed_id_conv_fh = None
+        if bed3_to_vcf_idx is not None:
+            bed_id_conv_fh = gzip.open(bed3_to_vcf_idx, "rb")
 
         # pre-process regions
         keys = set()  # what is that?
@@ -859,7 +871,8 @@ class MutationMap(object):
                                                               vcf_id_generator_fn=vcf_id_generator_fn,
                                                               vcf_search_regions=vcf_search_regions,
                                                               generate_rc=self.model_info_extractor.use_seq_only_rc,
-                                                              batch_size=batch_size)
+                                                              batch_size=batch_size,
+                                                              bed_id_conv_fh = bed_id_conv_fh)
 
             dl_batch_res = []
             # Keep the following metadata entries from the from the lines
@@ -905,6 +918,9 @@ class MutationMap(object):
 
         if vcf_fh is not None:
             vcf_fh.close()
+
+        if bed_id_conv_fh is not None:
+            bed_id_conv_fh.close()
 
         try:
             if temp_bed3_file is not None:

--- a/kipoi_veff/mutation_map.py
+++ b/kipoi_veff/mutation_map.py
@@ -209,7 +209,7 @@ def get_overlapping_bed_regions(dl_batch, seq_to_meta, bedtools_obj):
 def _generate_seq_sets_mutmap_iter(dl_ouput_schema, dl_batch, seq_to_mut, seq_to_meta,
                                    sample_counter, ref_sequences, bedtools_obj=None, vcf_fh=None,
                                    vcf_id_generator_fn=None, vcf_search_regions=False, generate_rc=True,
-                                   batch_size=32, bed_id_conv_fh = None):
+                                   batch_size=32, bed_id_conv_fh=None):
     all_meta_fields = list(set(seq_to_meta.values()))
 
     num_samples_in_batch = len(dl_batch['metadata'][all_meta_fields[0]]["chr"])
@@ -388,7 +388,6 @@ def get_ref_seq_from_seq_set(input_set, seq_to_meta, seq_to_str_converter, dl_ou
 
 
 class MutationMapDataMerger(object):
-
     def __init__(self, seq_to_meta):
         self.predictions = []
         self.pred_sets = []
@@ -429,7 +428,7 @@ class MutationMapDataMerger(object):
                     metadata_subset = get_genomicranges_line(batch_metadata[metadata_key], process_line)
                     subset_keys = ["chr", "start", "end", "strand"]
                     if not (isinstance(metadata_subset["strand"], list) or
-                            isinstance(metadata_subset["strand"], np.ndarray)):
+                                isinstance(metadata_subset["strand"], np.ndarray)):
                         subset_keys = ["chr", "start", "end"]
                     metadata_subset_dict = {k: metadata_subset[k][0] for k in subset_keys}
                     if "strand" not in metadata_subset_dict:
@@ -820,10 +819,10 @@ class MutationMap(object):
             raise Exception("If `vcf_fpath` is set then also `vcf_id_generator_fn` has to be defined!")
 
         dataloader_args, temp_bed3_file, vcf_search_regions, bed3_to_vcf_idx = self._setup_dataloader_kwargs(vcf_fpath,
-                                                                                            bed_fpath,
-                                                                                            vcf_to_region,
-                                                                                            bed_to_region,
-                                                                                            vcf_id_generator_fn)
+                                                                                                             bed_fpath,
+                                                                                                             vcf_to_region,
+                                                                                                             bed_to_region,
+                                                                                                             vcf_id_generator_fn)
 
         model_out_annotation = self.model_info_extractor.get_model_out_annotation()
 
@@ -872,7 +871,7 @@ class MutationMap(object):
                                                               vcf_search_regions=vcf_search_regions,
                                                               generate_rc=self.model_info_extractor.use_seq_only_rc,
                                                               batch_size=batch_size,
-                                                              bed_id_conv_fh = bed_id_conv_fh)
+                                                              bed_id_conv_fh=bed_id_conv_fh)
 
             dl_batch_res = []
             # Keep the following metadata entries from the from the lines

--- a/kipoi_veff/snv_predict.py
+++ b/kipoi_veff/snv_predict.py
@@ -239,7 +239,7 @@ def get_variants_in_regions_search_vcf(dl_batch, seq_to_meta, vcf_fh):
     return vcf_records, process_lines, process_seq_fields
 
 
-def get_variants_in_regions_sequential_vcf(dl_batch, seq_to_meta, vcf_fh, vcf_id_generator_fn, bed_id_conv_fh = None):
+def get_variants_in_regions_sequential_vcf(dl_batch, seq_to_meta, vcf_fh, vcf_id_generator_fn, bed_id_conv_fh=None):
     vcf_records = []  # list of vcf records to use
     process_ids = []  # id from genomic ranges metadata
     process_lines = []  # sample id within batch
@@ -286,7 +286,7 @@ def get_variants_df(seq_key, ranges_input_obj, vcf_records, process_lines, proce
                     "do_mutate": []}
 
     if ("strand" in ranges_input_obj) and (isinstance(ranges_input_obj["strand"], list) or
-                                           isinstance(ranges_input_obj["strand"], np.ndarray)):
+                                               isinstance(ranges_input_obj["strand"], np.ndarray)):
         preproc_conv["strand"] = []
 
     for i, record in enumerate(vcf_records):
@@ -302,7 +302,7 @@ def get_variants_df(seq_key, ranges_input_obj, vcf_records, process_lines, proce
             pre_new_vals["end"] = ranges_input_obj["end"][ranges_input_i]
             pre_new_vals["varpos_rel"] = int(record.POS) - pre_new_vals["start"]
             if not ((pre_new_vals["varpos_rel"] < 0) or
-                    (pre_new_vals["varpos_rel"] > (pre_new_vals["end"] - pre_new_vals["start"] + 1))):
+                        (pre_new_vals["varpos_rel"] > (pre_new_vals["end"] - pre_new_vals["start"] + 1))):
 
                 # If variant lies in the region then continue
                 pre_new_vals["do_mutate"] = True
@@ -333,7 +333,6 @@ def get_variants_df(seq_key, ranges_input_obj, vcf_records, process_lines, proce
 
 
 class SampleCounter():
-
     def __init__(self):
         self.sample_it_counter = 0
 
@@ -344,7 +343,7 @@ class SampleCounter():
 
 
 def _generate_seq_sets(dl_ouput_schema, dl_batch, vcf_fh, vcf_id_generator_fn, seq_to_mut, seq_to_meta,
-                       sample_counter, vcf_search_regions=False, generate_rc=True, bed_id_conv_fh = None):
+                       sample_counter, vcf_search_regions=False, generate_rc=True, bed_id_conv_fh=None):
     """
         Perform in-silico mutagenesis on what the dataloader has returned.
 
@@ -363,6 +362,7 @@ def _generate_seq_sets(dl_ouput_schema, dl_batch, vcf_fh, vcf_id_generator_fn, s
         `vcf_search_regions`: if `False` assume that the regions are labelled and only test variants/region combinations for
         which the label fits. If `True` find all variants overlapping with all regions and test all.
         `generate_rc`: generate also reverse complement sequences. Only makes sense if supported by model.
+        `bed_id_conv_fh`: fil handle that converts the bed file row index to a VCF variant index
         """
 
     all_meta_fields = list(set(seq_to_meta.values()))
@@ -554,8 +554,8 @@ def predict_snvs(model,
                             id = vcf_id_generator_fn(record)
                             for chrom, start, end in zip(region["chrom"], region["start"], region["end"]):
                                 ofh.append_interval(chrom=chrom, start=start, end=end, id=bed_line_ctr)
-                                idx_conv_fh.write(("%s\t%d\n"%(id, bed_line_ctr)).encode())
-                                bed_line_ctr +=1
+                                idx_conv_fh.write(("%s\t%d\n" % (id, bed_line_ctr)).encode())
+                                bed_line_ctr += 1
 
             vcf_fh.close()
     else:
@@ -628,7 +628,7 @@ def predict_snvs(model,
                                          seq_to_mut=seq_to_mut, seq_to_meta=seq_to_meta,
                                          sample_counter=sample_counter, vcf_search_regions=vcf_search_regions,
                                          generate_rc=model_info_extractor.use_seq_only_rc,
-                                         bed_id_conv_fh = bed_id_conv_fh)
+                                         bed_id_conv_fh=bed_id_conv_fh)
         if eval_kwargs is None:
             # No generated datapoint overlapped any VCF region
             continue

--- a/kipoi_veff/utils/generic.py
+++ b/kipoi_veff/utils/generic.py
@@ -207,7 +207,6 @@ class RegionGenerator(object):
 
 
 class SnvCenteredRg(RegionGenerator):
-
     def __init__(self, model_info_extractor, seq_length=None):
         """
         Arguments:
@@ -237,7 +236,6 @@ class SnvCenteredRg(RegionGenerator):
 
 
 class BedOverlappingRg(RegionGenerator):
-
     def __init__(self, model_info_extractor, seq_length=None):
         super(BedOverlappingRg, self).__init__(model_info_extractor)
         if seq_length is not None:
@@ -267,7 +265,6 @@ class BedOverlappingRg(RegionGenerator):
 
 
 class SnvPosRestrictedRg(RegionGenerator):
-
     def __init__(self, model_info_extractor, pybed_def, seq_length=None):
         super(SnvPosRestrictedRg, self).__init__(model_info_extractor)
         self.tabixed = pybed_def.tabix(in_place=False)
@@ -315,7 +312,6 @@ class SnvPosRestrictedRg(RegionGenerator):
 
 
 class ModelInfoExtractor(object):
-
     def __init__(self, model_obj, dataloader_obj):
         self.model = model_obj
         self.dataloader = dataloader_obj
@@ -479,6 +475,7 @@ def _get_seq_shape(dataloader, seq_field):
         orig_shape = dataloader.output_schema.inputs.shape
     return orig_shape
 
+
 def _get_seq_shape_model(model, seq_field):
     if isinstance(model.schema.inputs, dict):
         orig_shape = model.schema.inputs[seq_field].shape
@@ -527,7 +524,6 @@ class OneHotSeqExtractor(object):
 
 
 class StrSeqExtractor(object):
-
     def __init__(self, array_trafo=None):
         self.array_trafo = array_trafo
 
@@ -544,7 +540,6 @@ class StrSeqExtractor(object):
 
 
 class VariantLocalisation(object):
-
     def __init__(self):
         self.obj_keys = ["pp_line", "varpos_rel", "ref", "alt", "start", "end", "id", "do_mutate", "strand"]
         self.dummy_initialisable_keys = ["varpos_rel", "ref", "alt", "start", "end", "id", "strand"]
@@ -555,7 +550,7 @@ class VariantLocalisation(object):
         strand_avail = False
         strand_default = "."
         if ("strand" in ranges_input_obj) and (isinstance(ranges_input_obj["strand"], list) or
-                                               isinstance(ranges_input_obj["strand"], np.ndarray)):
+                                                   isinstance(ranges_input_obj["strand"], np.ndarray)):
             strand_avail = True
 
         # If the strand is a single string value rather than a list or numpy array than use that as a
@@ -581,7 +576,7 @@ class VariantLocalisation(object):
                 pre_new_vals["varpos_rel"] = int(record.POS) - pre_new_vals["start"]
                 # Check if variant position is valid
                 if not ((pre_new_vals["varpos_rel"] < 0) or
-                        (pre_new_vals["varpos_rel"] > (pre_new_vals["end"] - pre_new_vals["start"] + 1))):
+                            (pre_new_vals["varpos_rel"] > (pre_new_vals["end"] - pre_new_vals["start"] + 1))):
 
                     # If variant lies in the region then actually mutate it with the first alternative allele
                     pre_new_vals["do_mutate"] = True

--- a/kipoi_veff/utils/generic.py
+++ b/kipoi_veff/utils/generic.py
@@ -336,13 +336,19 @@ class ModelInfoExtractor(object):
                             "assuming 1-hot encoded DNA sequence." % str(seq_field))
 
             if (special_type is None) or (special_type == kipoi.components.ArraySpecialType.DNASeq):
-                dna_seq_trafo = ReshapeDna(_get_seq_shape(dataloader_obj, seq_field))
+                try:
+                    dna_seq_trafo = ReshapeDna(_get_seq_shape(dataloader_obj, seq_field))
+                except:
+                    dna_seq_trafo = ReshapeDna(_get_seq_shape_model(model_obj, seq_field))
                 self.seq_input_mutator[seq_field] = OneHotSequenceMutator(dna_seq_trafo)
                 self.seq_to_str_converter[seq_field] = OneHotSeqExtractor(dna_seq_trafo)
                 self.seq_input_array_trafo[seq_field] = dna_seq_trafo
 
             if special_type == kipoi.components.ArraySpecialType.DNAStringSeq:
-                dna_seq_trafo = ReshapeDnaString(_get_seq_shape(dataloader_obj, seq_field))
+                try:
+                    dna_seq_trafo = ReshapeDnaString(_get_seq_shape(dataloader_obj, seq_field))
+                except:
+                    dna_seq_trafo = ReshapeDnaString(_get_seq_shape_model(model_obj, seq_field))
                 self.seq_input_mutator[seq_field] = DNAStringSequenceMutator(dna_seq_trafo)
                 self.seq_to_str_converter[seq_field] = StrSeqExtractor(dna_seq_trafo)
                 self.seq_input_array_trafo[seq_field] = dna_seq_trafo
@@ -471,6 +477,15 @@ def _get_seq_shape(dataloader, seq_field):
         orig_shape = [x.shape for x in dataloader.output_schema.inputs if x.name == seq_field][0]
     else:
         orig_shape = dataloader.output_schema.inputs.shape
+    return orig_shape
+
+def _get_seq_shape_model(model, seq_field):
+    if isinstance(model.schema.inputs, dict):
+        orig_shape = model.schema.inputs[seq_field].shape
+    elif isinstance(model.schema.inputs, list):
+        orig_shape = [x.shape for x in model.schema.inputs if x.name == seq_field][0]
+    else:
+        orig_shape = model.schema.inputs.shape
     return orig_shape
 
 

--- a/tests/test_model_info_extraction.py
+++ b/tests/test_model_info_extraction.py
@@ -53,6 +53,56 @@ postprocessing:
             - intervals_file
 """
 
+
+dataloader_yaml_noshapes = """
+type: Dataset
+defined_as: dataloader.py::SeqDistDataset
+args:
+    intervals_file:
+        doc: tsv file with `chrom start end id score strand`
+        type: str
+        example: example_files/intervals.tsv
+info:
+    authors:
+        - name: Roman Kreuzhuber
+          github: krrome
+    doc: DUMMY
+output_schema:
+    inputs:
+        seq_a:
+            shape: ()
+            special_type: DNASeq
+            doc: One-hot encoded RNA sequence
+            associated_metadata: ranges
+        seq_b:
+            shape: ()
+            special_type: DNAStringSeq
+            doc: DNA sequence as a string
+            associated_metadata: ranges
+        seq_c:
+            shape: ()
+            special_type: DNASeq
+            doc: One-hot encoded RNA sequence
+            associated_metadata: ranges_b
+        something:
+            shape: ()
+            doc: Something
+    targets:
+        shape: (1, )
+        doc: Measured binding strength
+    metadata:
+        ranges:
+            type: GenomicRanges
+            doc: Ranges describing inputs.seq_a and inputs.seq_b
+        ranges_b:
+            type: GenomicRanges
+            doc: Ranges describing inputs.seq_c
+postprocessing:
+    variant_effects:
+        bed_input:
+            - intervals_file
+"""
+
 model_yaml = """
 type: keras
 args:
@@ -107,6 +157,18 @@ def test_ModelDescription():
             ssrs = ""
         model = ModelDescription.from_config(from_yaml(model_yaml % (seq_string_shape, ssrs)))
         dataloader = DataLoaderDescription.from_config(from_yaml(dataloader_yaml % (seq_string_shape)))
+        mi = ModelInfoExtractor(model, dataloader)
+        assert mi.use_seq_only_rc == rc_support
+        assert all([isinstance(mi.seq_input_mutator[sl], OneHotSequenceMutator) for sl in ["seq_a", "seq_c"]])
+        assert all([isinstance(mi.seq_input_mutator[sl], DNAStringSequenceMutator) for sl in ["seq_b"]])
+        assert all([mi.seq_input_metadata[sl] == "ranges" for sl in ["seq_a", "seq_b"]])
+        assert all([mi.seq_input_metadata[sl] == "ranges_b" for sl in ["seq_c"]])
+        assert all([isinstance(mi.seq_input_array_trafo[sl], ReshapeDna) for sl in ["seq_a", "seq_c"]])
+        assert all([isinstance(mi.seq_input_array_trafo[sl], ReshapeDnaString) for sl in ["seq_b"]])
+
+        # Test whether the model infor extractor also works without missing shapes in the dataloader schema definition.
+        model = ModelDescription.from_config(from_yaml(model_yaml % (seq_string_shape, ssrs)))
+        dataloader = DataLoaderDescription.from_config(from_yaml(dataloader_yaml_noshapes))
         mi = ModelInfoExtractor(model, dataloader)
         assert mi.use_seq_only_rc == rc_support
         assert all([isinstance(mi.seq_input_mutator[sl], OneHotSequenceMutator) for sl in ["seq_a", "seq_c"]])


### PR DESCRIPTION
Comply with dl repo:
- if the dataloader doesn't have any shape information of the generated inputs then derive them from the model object

allow bed row index as variant index:
- the index in the GenomicRanges object returned by the dataloader in the metadata field can now be the row index of the bed file. the link between the bed file row index and the variant in the vcf is stored in a gzipped temporary file.
- implemented for variant effect prediction and for mutation maps.