### PR TITLE
added --singularity to score_variants

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 
 requirements = [
-    "kipoi>=0.5.8",
+    "kipoi>=0.6.1",
     # vep
     "pyvcf",
     "cyvcf2",


### PR DESCRIPTION
## Example

Follow this tutorial: https://github.com/kipoi/examples/tree/master/2-score_variants
and add `--singularity` to the command:

```bash
kipoi veff score_variants DeepBind/Homo_sapiens/TF/D00328.018_ChIP-seq_CTCF \
   --dataloader_args='{"fasta_file": "input/hg19.chr22.fa"}' \
   -i input/clinvar_20180429.pathogenic.chr22.vcf.gz \
   -s ref alt diff \
   -o /tmp/annotated.vcf --singularity
```